### PR TITLE
Process Roam Graph Daily Pages into One Doc

### DIFF
--- a/notebooks/roam_to_nblm.ipynb
+++ b/notebooks/roam_to_nblm.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "20d62d58-f346-47fa-be8a-3b2de068db10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import re\n",
+    "from datetime import datetime\n",
+    "\n",
+    "import dr_util.file_utils as fu\n",
+    "import roam_man.process_utils as pu\n",
+    "from roam_man.roam_graph import RoamGraph, roam_data_to_full_str"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "b07755d4-2df6-4b29-a5ff-530f994781f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89f32141-5159-4d7d-89ee-8c77cffa3336",
+   "metadata": {},
+   "source": [
+    "## Util Definitions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "93fca9f9-0bee-4885-8d7a-48ba7d1c2f80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def is_page_empty(page):\n",
+    "    if len(page.children) == 0:\n",
+    "        return True\n",
+    "\n",
+    "    # Drop the title\n",
+    "    page_strs = page.to_str_full(verbose=False).split(\"\\n\")[1:]\n",
+    "    \n",
+    "    for ps in page_strs:\n",
+    "        psreal = ps.strip().strip(\"-\")\n",
+    "        if len(psreal) > 0:\n",
+    "            return False\n",
+    "\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "id": "40c8f4da-31f5-4f97-90b4-c5236191fce9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Helper function to parse date strings like \"May 8th, 2024\"\n",
+    "def parse_date(date_str):\n",
+    "    # Remove the ordinal suffix from the day part (e.g., \"8th\" -> \"8\")\n",
+    "    cleaned_date_str = re.sub(r'(\\d+)(st|nd|rd|th)', r'\\1', date_str)\n",
+    "    # Parse the cleaned date string into a datetime object\n",
+    "    return datetime.strptime(cleaned_date_str, \"%B %d, %Y\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "id": "8a432186-6efc-4652-9817-bad4b466e074",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_pages_by_year(graph, year='all', drop_empty=False):\n",
+    "    title_sets = pu.page_node_list_to_title_sets(graph.roam_pages, graph.uid_to_title)\n",
+    "    dp = title_sets['daily_pages']\n",
+    "    if year == 'all':\n",
+    "        this_year = dp\n",
+    "    else:\n",
+    "        this_year = [pt for pt in dp if year in pt]\n",
+    "    ty_sorted = sorted(this_year, key=lambda st: parse_date(st))\n",
+    "    nodes = [graph.get_page_node(pt) for pt in ty_sorted]\n",
+    "    if drop_empty:\n",
+    "        nodes = [n for n in nodes if not is_page_empty(n)]\n",
+    "    return nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "7e3a8893-225e-45a4-bd8b-572d1d8fc52e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def merge_all_daily_pages(graph, year='all'):\n",
+    "    tydp_nonempty = get_pages_by_year(graph, year=year, drop_empty=True)\n",
+    "    buffer = io.StringIO()\n",
+    "    for dp in tydp_nonempty:\n",
+    "        buffer.write(dp.to_str_full(verbose=False))\n",
+    "        buffer.write(\"\\n\\n\")\n",
+    "    rep = buffer.getvalue()\n",
+    "    buffer.close()\n",
+    "    return rep"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c67ffc4f-d45e-460e-a924-a952c2dfae66",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "### Testing the Utils"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "55c7c732-87c5-4262-a51c-d5c6ade79dcd",
+   "metadata": {},
+   "source": [
+    "# Testing is_page_empty and get_pages_by_year\n",
+    "this_year_dp = get_pages_by_year(rg, year='2024', drop_empty=False)\n",
+    "\n",
+    "## Page 0\n",
+    "February 12th, 2024\n",
+    "  uid='02-12-2024' refs=[]\n",
+    "\n",
+    "empty -> True\n",
+    "\n",
+    "## Page 2\n",
+    "April 4th, 2024\n",
+    "  uid='04-04-2024' refs=[]\n",
+    "\n",
+    " - \n",
+    "\n",
+    "empty -> True\n",
+    "\n",
+    "## Page -1\n",
+    "May 7th, 2024\n",
+    "  uid='05-07-2024' refs=[]\n",
+    "\n",
+    " - Today I\n",
+    " - Best way to prepare for the meeting\n",
+    " - ....\n",
+    "\n",
+    "empty -> False\n",
+    "\n",
+    "## Whole Thing\n",
+    "this_year_dp = get_pages_by_year(rg, year='2024', drop_empty=False)\n",
+    "tydp_nonempty = get_pages_by_year(rg, year='2024', drop_empty=True)\n",
+    "len(this_year_dp), len(tydp_nonempty)\n",
+    "-> (50, 23)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86cf2f85-57d8-44ce-aa43-c0e463b7a709",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e29eef4e-26a3-4a7e-ad4d-8e0ac4c01f6e",
+   "metadata": {},
+   "source": [
+    "## The Ultimate Goal: Import graph dump formatted non-empty daily pages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bc54fc75-9c41-4891-9dda-c375801dbb67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rg = RoamGraph(\"/Users/daniellerothermel/Desktop/drotherm_roam-2024-10-02-15-16-48.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e4a71e67-bede-4ace-aac3-d5a20e173269",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "title_sets = pu.page_node_list_to_title_sets(rg.roam_pages, rg.uid_to_title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "id": "afb3bcc5-3e9c-4382-948a-ce81db7fde81",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 101,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The Ultimate Goal: And it Worked!!!\n",
+    "all_dps = merge_all_daily_pages(rg, year='2024')\n",
+    "fu.dump_file(all_dps, '/Users/daniellerothermel/Desktop/all_daily_pages_2024_drotherm_roam_2024.10.02.txt')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/roam_man/roam_graph.py
+++ b/src/roam_man/roam_graph.py
@@ -7,7 +7,13 @@ from dr_util import file_utils as fu
 
 # To use: print(buffer.getvalue()); buffer.close()
 def add_roam_elem_str_to_buffer(
-    uid, refs=[], title=None, string=None, buffer=None, depth=0, verbose=True,
+    uid,
+    refs=[],
+    title=None,
+    string=None,
+    buffer=None,
+    depth=0,
+    verbose=True,
 ):
     if buffer is None:
         buffer = io.StringIO()
@@ -30,6 +36,7 @@ def add_roam_elem_str_to_buffer(
 #   with the expected keys
 def roam_data_to_full_str(roam_data_elem, verbose=True):
     buffer = io.StringIO()
+
     def add_node_subtree(node, first=False, depth=0):
         if not isinstance(node, dict):
             node = node.__dict__
@@ -48,7 +55,7 @@ def roam_data_to_full_str(roam_data_elem, verbose=True):
         )
         n_children = node.get("children", [])
         for nc in n_children:
-            add_node_subtree(nc, first=False, depth=depth+1)
+            add_node_subtree(nc, first=False, depth=depth + 1)
 
     add_node_subtree(roam_data_elem, first=True, depth=0)
     result = buffer.getvalue()

--- a/src/roam_man/roam_graph.py
+++ b/src/roam_man/roam_graph.py
@@ -7,7 +7,7 @@ from dr_util import file_utils as fu
 
 # To use: print(buffer.getvalue()); buffer.close()
 def add_roam_elem_str_to_buffer(
-    uid, refs=[], title=None, string=None, buffer=None, depth=0
+    uid, refs=[], title=None, string=None, buffer=None, depth=0, verbose=True,
 ):
     if buffer is None:
         buffer = io.StringIO()
@@ -15,30 +15,27 @@ def add_roam_elem_str_to_buffer(
     indent = "  " * depth
     if title is not None:
         assert depth == 0  # only pages (depth 0 nodes) have titles
-        buffer.write(f"{title}\n {indent} {uid=} {refs=}\n")
+        buffer.write(f"{title}\n")
+        if verbose:
+            buffer.write(f" {indent} {uid=} {refs=}\n")
     else:
         assert string is not None  # no title means yes string
         buffer.write(f"{indent} - {string}")
-        if len(refs) > 0:
+        if len(refs) > 0 and verbose:
             buffer.write(f"\n{indent} ==> {uid=} {refs=}\n")
     return buffer
 
 
 # Works for anything where the __dict__ method returns a dict
 #   with the expected keys
-def roam_data_to_full_str(roam_data_elem):
+def roam_data_to_full_str(roam_data_elem, verbose=True):
     buffer = io.StringIO()
-    nodes = [roam_data_elem]
-    i = 0
-
-    while i < len(nodes):
-        if i > 0:
-            buffer.write("\n")
-
-        node = nodes[i]
+    def add_node_subtree(node, first=False, depth=0):
         if not isinstance(node, dict):
             node = node.__dict__
 
+        if not first:
+            buffer.write("\n")
         refs = [r if isinstance(r, str) else r["uid"] for r in node.get("refs", [])]
         add_roam_elem_str_to_buffer(
             uid=node["uid"],
@@ -46,14 +43,14 @@ def roam_data_to_full_str(roam_data_elem):
             title=node.get("title", None),
             string=node.get("string", None),
             buffer=buffer,
+            depth=depth,
+            verbose=verbose,
         )
+        n_children = node.get("children", [])
+        for nc in n_children:
+            add_node_subtree(nc, first=False, depth=depth+1)
 
-        # Safely add children to the end of the list
-        nodes.extend(node.get("children", []))
-
-        # Move to the next node
-        i += 1
-
+    add_node_subtree(roam_data_elem, first=True, depth=0)
     result = buffer.getvalue()
     buffer.close()
     return result
@@ -100,13 +97,17 @@ class RoamNode:
             title=self.title,
             string=self.string,
             depth=self.depth,
+            verbose=True,
         )
         rep = buffer.getvalue()
         buffer.close()
         return rep
 
-    def print_full(self):
-        print(roam_data_to_full_str(self))
+    def print_full(self, verbose=True):
+        print(roam_data_to_full_str(self, verbose=verbose))
+
+    def to_str_full(self, verbose=True):
+        return roam_data_to_full_str(self, verbose=verbose)
 
 
 # Uses validation_utils


### PR DESCRIPTION
- Fixed some bugs
    - The page print out was breadth wise instead of depth wise (so not correct)
    - Added support for printing the full string or returning it
- Added some utils in the jupyter notebook (TODO: move to a python file after testing)
    - is_page_empty - checks if there are any non-space characters on page
    - parse_date - parses the roam date string format into datetime
    - get_pages_by_year - return all page nodes that are within the given year and aren't empty
    - merge_all_daily_pages - returns the string of all the daily pages that are non-empty in order of date


- Next up: clean these up, move them to a file, test them, return things in order to begin with.
